### PR TITLE
Revert "Add all missing peer dependencies (#355)"

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,6 @@
     "node": ">=12"
   },
   "dependencies": {
-    "@babel/core": "^7.9.0",
     "@material-ui/core": "^4.9.11",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.50",
@@ -14,7 +13,6 @@
     "@storybook/addon-actions": "^5.3.18",
     "@storybook/addon-links": "^5.3.18",
     "@storybook/addons": "^5.3.14",
-    "@storybook/core": "^5.3.18",
     "@storybook/preset-create-react-app": "^2.1.1",
     "@storybook/react": "^5.3.18",
     "@testing-library/jest-dom": "^5.5.0",
@@ -31,10 +29,8 @@
     "@types/testing-library__react": "^10.0.1",
     "@types/uuid": "^7.0.2",
     "@types/webpack-env": "^1.15.1",
-    "babel-loader": "^8.0.6",
     "fp-ts": "^2.5.3",
     "io-ts": "^2.2.0",
-    "jest": "24.9.0",
     "jest-junit": "^10.0.0",
     "prettier": "2.0.4",
     "react": "^16.13.1",
@@ -42,14 +38,11 @@
     "react-redux": "^7.2.0",
     "react-scripts": "3.4.0",
     "react-transition-group": "^4.3.0",
-    "redux": "^4.0.5",
     "redux-logger": "^3.0.6",
     "redux-persist": "^6.0.0",
-    "regenerator-runtime": "^0.13.5",
     "storybook": "^5.3.18",
     "typescript": "3.8.3",
-    "uuid": "^7.0.3",
-    "webpack": "4.41.5"
+    "uuid": "^7.0.3"
   },
   "resolutions": {
     "@types/testing-library__react/@types/testing-library__dom": "7.0.1"

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -76,7 +76,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@7.9.0", "@babel/core@^7.1.0", "@babel/core@^7.1.6", "@babel/core@^7.4.5", "@babel/core@^7.7.5", "@babel/core@^7.9.0":
+"@babel/core@7.9.0", "@babel/core@^7.1.0", "@babel/core@^7.1.6", "@babel/core@^7.4.5", "@babel/core@^7.7.5":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.9.0.tgz#ac977b538b77e132ff706f3b8a4dbad09c03c56e"
   integrity sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==
@@ -2101,7 +2101,7 @@
   dependencies:
     core-js "^3.0.1"
 
-"@storybook/core@5.3.18", "@storybook/core@^5.3.18":
+"@storybook/core@5.3.18":
   version "5.3.18"
   resolved "https://registry.yarnpkg.com/@storybook/core/-/core-5.3.18.tgz#3f3c0498275826c1cc4368aba203ac17a6ae5c9c"
   integrity sha512-XQb/UQb+Ohuaw0GhKKYzvmuuh5Tit93f2cLZD9QCSWUPvDGmLG5g91Y9NbUr4Ap3mANT3NksMNhkAV0GxExEkg==
@@ -3596,7 +3596,7 @@ babel-jest@^24.9.0:
     chalk "^2.4.2"
     slash "^2.0.0"
 
-babel-loader@8.0.6, babel-loader@^8.0.6:
+babel-loader@8.0.6:
   version "8.0.6"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.0.6.tgz#e33bdb6f362b03f4bb141a0c21ab87c501b70dfb"
   integrity sha512-4BmWKtBOBm13uoUwd08UwjZlaw3O9GWf456R9j+5YykFZ6LUIjIKLc0zEZf+hauxPOJs96C8k6FvYD09vWzhYw==
@@ -12975,7 +12975,7 @@ redux@^3.6.0:
     loose-envify "^1.1.0"
     symbol-observable "^1.0.3"
 
-redux@^4.0.0, redux@^4.0.5:
+redux@^4.0.0:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"
   integrity sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==
@@ -13020,11 +13020,6 @@ regenerator-runtime@^0.13.2, regenerator-runtime@^0.13.3, regenerator-runtime@^0
   version "0.13.4"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz#e96bf612a3362d12bb69f7e8f74ffeab25c7ac91"
   integrity sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g==
-
-regenerator-runtime@^0.13.5:
-  version "0.13.5"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
-  integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
 
 regenerator-transform@^0.14.0:
   version "0.14.1"


### PR DESCRIPTION
This reverts commit 1293385ccf0abe68b106819029167f74e65ab510.

One of these dependencies is causing a compiler bug that breaks
character rendering in the board by incorrectly optimizing out the part
that actually renders characters :(

I haven't done a full investigation to figure out why, but am instead
using this as a motivation to get off create-react-app