### PR TITLE
Update localstack to 0.12.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,43 +61,39 @@ commands:
 jobs:
   api:
     docker:
-      - image: cimg/base:2021.07
+      - image: circleci/python:3.9
     working_directory: ~/repo/api
-    environment:
-      # Enable the legacy docker client for localstack
-      # The Sdk docker client crashes if docker isn't available, even though it's just checking for a container name,
-      # which is not necessary to run the tests
-      # https://github.com/localstack/localstack/issues/4692
-      LEGACY_DOCKER_CLIENT: "true"
     steps:
       - checkout:
           path: ~/repo
-      - setup_remote_docker:
-          version: 20.10.6
+      - restore_cache:
+          keys:
+            # Restore the cache with the exact dependencies,
+            - api-deps-v3-{{ checksum "poetry.lock" }}
+            # or, failing that, just the most recent cache entry
+            - api-deps-v3
       - run:
-          name: Sign in to Docker Hub
-          command: docker login -u ${DOCKER_USERNAME} -p ${DOCKER_ACCESS_TOKEN}
+          name: Configure Poetry
+          command: poetry config virtualenvs.in-project true && poetry config virtualenvs.path .venv
       - run:
-          name: Build api Docker image
-          command: ./build_image_ci ttbud/api
+          name: Install Deps
+          command: poetry install
+      - save_cache:
+          key: api-deps-v3-{{ checksum "poetry.lock" }}
+          paths:
+            - .venv
       - run:
           name: Check Code Format
-          command: docker run ttbud/api black -S src tests load main.py --check
+          command: poetry run black -S src tests load main.py --check
       - run:
           name: Typecheck
-          command: docker run ttbud/api mypy src tests load main.py
+          command: poetry run mypy src tests load main.py
       - run:
           name: Lint
-          command: docker run ttbud/api flake8 src tests load main.py
+          command: poetry run flake8 src tests load main.py
       - run:
           name: Run Tests
-          command: |
-            docker run --env LEGACY_DOCKER_CLIENT --name api-tests ttbud/api pytest tests --junitxml=test-results/junit.xml
-      - run:
-          name: Extract Test Results
-          command: |
-            mkdir -p test-results
-            docker cp api-tests:/home/appuser/app/test-results/junit.xml test-results/junit.xml
+          command: poetry run pytest tests --junitxml=test-results/junit.xml
       - store_test_results:
           path: test-results
   web:

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -6,16 +6,6 @@ WORKDIR /home/appuser/app
 RUN chown appuser:appuser /home/appuser/app
 USER appuser
 
-# ONBUILD COPY --from doesn't work unless it's a named stage in the build
-FROM docker:20.10.8 as ttbud_docker
-
-# In dev, base needs to have the docker cli installed so that localstack can do its thing
-FROM base as base_dev
-ONBUILD COPY --from=ttbud_docker /usr/local/bin/docker /usr/local/bin
-
-# In prod, we don't need the docker cli
-FROM base as base_prod
-
 FROM base as builder
 
 USER root
@@ -48,7 +38,7 @@ RUN . /home/appuser/venv/bin/activate && \
 
 COPY --chown=appuser:appuser . ./
 
-FROM base_${BUILD_ENV}
+FROM base
 
 COPY --chown=appuser:appuser --from=builder /home/appuser/venv /home/appuser/venv/
 COPY --chown=appuser:appuser --from=builder /home/appuser/app /home/appuser/app/

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -388,27 +388,8 @@ category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
-[package.dependencies]
-toml = {version = "*", optional = true, markers = "extra == \"toml\""}
-
 [package.extras]
 toml = ["toml"]
-
-[[package]]
-name = "coveralls"
-version = "3.1.0"
-description = "Show coverage stats online via coveralls.io"
-category = "dev"
-optional = false
-python-versions = ">= 3.5"
-
-[package.dependencies]
-coverage = ">=4.1,<6.0"
-docopt = ">=0.6.1"
-requests = ">=1.0.0"
-
-[package.extras]
-yaml = ["PyYAML (>=3.10)"]
 
 [[package]]
 name = "crontab"
@@ -478,29 +459,20 @@ IDNA = ["idna (>=2.1)"]
 
 [[package]]
 name = "docker"
-version = "4.2.2"
+version = "5.0.0"
 description = "A Python library for the Docker Engine API."
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.6"
 
 [package.dependencies]
-pypiwin32 = {version = "223", markers = "sys_platform == \"win32\" and python_version >= \"3.6\""}
+pywin32 = {version = "227", markers = "sys_platform == \"win32\""}
 requests = ">=2.14.2,<2.18.0 || >2.18.0"
-six = ">=1.4.0"
 websocket-client = ">=0.32.0"
 
 [package.extras]
 ssh = ["paramiko (>=2.4.2)"]
-tls = ["pyOpenSSL (>=17.5.0)", "cryptography (>=1.3.4)", "idna (>=2.0.0)"]
-
-[[package]]
-name = "docopt"
-version = "0.6.2"
-description = "Pythonic argument parser, that will make you smile"
-category = "dev"
-optional = false
-python-versions = "*"
+tls = ["pyOpenSSL (>=17.5.0)", "cryptography (>=3.4.7)", "idna (>=2.0.0)"]
 
 [[package]]
 name = "docutils"
@@ -642,14 +614,6 @@ python-versions = "*"
 [package.dependencies]
 Flask = ">=0.10"
 PyYAML = ">=3.0"
-
-[[package]]
-name = "forbiddenfruit"
-version = "0.1.3"
-description = "Patch python built-in objects"
-category = "dev"
-optional = false
-python-versions = "*"
 
 [[package]]
 name = "future"
@@ -907,7 +871,7 @@ six = "*"
 
 [[package]]
 name = "localstack"
-version = "0.12.17.3"
+version = "0.12.18.1"
 description = "LocalStack - A fully functional local Cloud stack"
 category = "dev"
 optional = false
@@ -924,43 +888,37 @@ botocore = {version = ">=1.12.13", optional = true, markers = "extra == \"full\"
 cachetools = {version = ">=3.1.1,<4.0.0", optional = true, markers = "extra == \"full\""}
 cbor2 = {version = ">=5.2.0", optional = true, markers = "extra == \"full\""}
 click = ">=7.0"
-coverage = {version = ">=5.5", extras = ["toml"], optional = true, markers = "extra == \"full\""}
-coveralls = {version = "3.1.0", optional = true, markers = "extra == \"full\""}
 crontab = {version = ">=0.22.6", optional = true, markers = "extra == \"full\""}
 cryptography = {version = "<3.4", optional = true, markers = "extra == \"full\""}
-dnspython = "1.16.0"
-docker = ">=3.7.2"
-docopt = ">=0.6.2"
+docker = "5.0.0"
 elasticsearch = {version = ">=7.0.0,<8.0.0", optional = true, markers = "extra == \"full\""}
 flask = {version = ">=1.0.2", optional = true, markers = "extra == \"full\""}
 flask-cors = {version = ">=3.0.3,<3.1.0", optional = true, markers = "extra == \"full\""}
 flask_swagger = {version = "0.2.12", optional = true, markers = "extra == \"full\""}
-forbiddenfruit = {version = "0.1.3", optional = true, markers = "extra == \"full\""}
-jsondiff = {version = ">=1.2.0", optional = true, markers = "extra == \"full\""}
 jsonpatch = {version = ">=1.24,<2.0", optional = true, markers = "extra == \"full\""}
 jsonpath-rw = {version = ">=1.4.0,<2.0.0", optional = true, markers = "extra == \"full\""}
-localstack-client = ">=1.20"
+localstack-client = ">=1.24"
 localstack-ext = ">=0.12.16"
 moto-ext = {version = ">=2.0.3.23", extras = ["all"], optional = true, markers = "extra == \"full\""}
+pproxy = {version = ">=2.7.0", optional = true, markers = "extra == \"full\""}
 psutil = {version = ">=5.4.8,<6.0.0", optional = true, markers = "extra == \"full\""}
-pympler = {version = ">=0.6", optional = true, markers = "extra == \"full\""}
 pyopenssl = {version = "17.5.0", optional = true, markers = "extra == \"full\""}
-pytest = {version = "6.2.4", optional = true, markers = "extra == \"full\""}
-pytest-httpserver = {version = ">=1.0.1", optional = true, markers = "extra == \"full\""}
-pytest-rerunfailures = {version = "10.0", optional = true, markers = "extra == \"full\""}
 pyyaml = ">=5.1"
 Quart = {version = ">=0.6.15", optional = true, markers = "extra == \"full\""}
 readerwriterlock = {version = ">=1.0.7", optional = true, markers = "extra == \"full\""}
 requests = ">=2.20.0,<2.26"
 requests-aws4auth = {version = "0.9", optional = true, markers = "extra == \"full\""}
 rich = ">=10.7.0"
-sasl = {version = ">=0.2.1", optional = true, markers = "extra == \"full\""}
 six = ">=1.12.0"
 stevedore = ">=3.4.0"
 xmltodict = {version = ">=0.11.0", optional = true, markers = "extra == \"full\""}
 
 [package.extras]
-full = ["airspeed (>=0.5.14)", "amazon_kclpy-ext (==1.5.1)", "aws-sam-translator (>=1.15.1)", "awscli (>=1.14.18)", "boto (>=2.49.0)", "botocore (>=1.12.13)", "cachetools (>=3.1.1,<4.0.0)", "cbor2 (>=5.2.0)", "coverage[toml] (>=5.5)", "coveralls (==3.1.0)", "crontab (>=0.22.6)", "cryptography (<3.4)", "elasticsearch (>=7.0.0,<8.0.0)", "flask (>=1.0.2)", "flask-cors (>=3.0.3,<3.1.0)", "flask_swagger (==0.2.12)", "forbiddenfruit (==0.1.3)", "jsondiff (>=1.2.0)", "jsonpatch (>=1.24,<2.0)", "jsonpath-rw (>=1.4.0,<2.0.0)", "localstack-ext[full] (>=0.12.16)", "moto-ext[all] (>=2.0.3.23)", "psutil (>=5.4.8,<6.0.0)", "pympler (>=0.6)", "pyopenssl (==17.5.0)", "pytest (==6.2.4)", "pytest-httpserver (>=1.0.1)", "pytest-rerunfailures (==10.0)", "Quart (>=0.6.15)", "readerwriterlock (>=1.0.7)", "requests-aws4auth (==0.9)", "sasl (>=0.2.1)", "xmltodict (>=0.11.0)"]
+cli = ["boto3 (>=1.14.33)", "click (>=7.0)", "docker (==5.0.0)", "localstack-ext (>=0.12.16)", "localstack-client (>=1.24)", "pyyaml (>=5.1)", "rich (>=10.7.0)", "requests (>=2.20.0,<2.26)", "six (>=1.12.0)", "stevedore (>=3.4.0)", "dataclasses"]
+dev = ["black (==21.6b0)", "coveralls (==3.1.0)", "cython", "flake8 (>=3.6.0)", "flake8-black (>=0.2.1)", "flake8-isort (>=4.0.0)", "flake8-quotes (>=0.11.0)", "pre-commit (==2.13.0)", "pyproject-flake8", "isort (==5.9.1)"]
+full = ["boto3 (>=1.14.33)", "click (>=7.0)", "docker (==5.0.0)", "localstack-ext (>=0.12.16)", "localstack-client (>=1.24)", "pyyaml (>=5.1)", "rich (>=10.7.0)", "requests (>=2.20.0,<2.26)", "six (>=1.12.0)", "stevedore (>=3.4.0)", "airspeed (>=0.5.14)", "amazon_kclpy-ext (==1.5.1)", "aws-sam-translator (>=1.15.1)", "awscli (>=1.14.18)", "boto (>=2.49.0)", "botocore (>=1.12.13)", "cachetools (>=3.1.1,<4.0.0)", "cbor2 (>=5.2.0)", "crontab (>=0.22.6)", "cryptography (<3.4)", "elasticsearch (>=7.0.0,<8.0.0)", "flask (>=1.0.2)", "flask-cors (>=3.0.3,<3.1.0)", "flask_swagger (==0.2.12)", "jsonpatch (>=1.24,<2.0)", "jsonpath-rw (>=1.4.0,<2.0.0)", "localstack-ext[full] (>=0.12.16)", "moto-ext[all] (>=2.0.3.23)", "pproxy (>=2.7.0)", "psutil (>=5.4.8,<6.0.0)", "pyopenssl (==17.5.0)", "Quart (>=0.6.15)", "readerwriterlock (>=1.0.7)", "requests-aws4auth (==0.9)", "xmltodict (>=0.11.0)", "dataclasses"]
+runtime = ["airspeed (>=0.5.14)", "amazon_kclpy-ext (==1.5.1)", "aws-sam-translator (>=1.15.1)", "awscli (>=1.14.18)", "boto (>=2.49.0)", "botocore (>=1.12.13)", "cachetools (>=3.1.1,<4.0.0)", "cbor2 (>=5.2.0)", "crontab (>=0.22.6)", "cryptography (<3.4)", "elasticsearch (>=7.0.0,<8.0.0)", "flask (>=1.0.2)", "flask-cors (>=3.0.3,<3.1.0)", "flask_swagger (==0.2.12)", "jsonpatch (>=1.24,<2.0)", "jsonpath-rw (>=1.4.0,<2.0.0)", "localstack-ext[full] (>=0.12.16)", "moto-ext[all] (>=2.0.3.23)", "pproxy (>=2.7.0)", "psutil (>=5.4.8,<6.0.0)", "pyopenssl (==17.5.0)", "Quart (>=0.6.15)", "readerwriterlock (>=1.0.7)", "requests-aws4auth (==0.9)", "xmltodict (>=0.11.0)"]
+test = ["pytest (==6.2.4)", "pytest-httpserver (>=1.0.1)", "pytest-rerunfailures (==10.0)", "coverage[toml] (>=5.5)"]
 
 [[package]]
 name = "localstack-client"
@@ -1064,7 +1022,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "moto-ext"
-version = "2.2.3.2"
+version = "2.2.3.4"
 description = "A library that allows your python tests to easily mock out the boto library"
 category = "dev"
 optional = false
@@ -1107,7 +1065,7 @@ efs = ["sshpubkeys (>=3.1.0)"]
 iotdata = ["jsondiff (>=1.1.2)"]
 s3 = ["PyYAML (>=5.1)"]
 server = ["PyYAML (>=5.1)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "ecdsa (<0.15)", "docker (>=2.5.1)", "jsondiff (>=1.1.2)", "aws-xray-sdk (>=0.93,!=0.96)", "idna (>=2.5,<3)", "cfn-lint (>=0.4.0)", "sshpubkeys (>=3.1.0)", "setuptools", "flask", "flask-cors"]
-ssm = ["PyYAML (>=5.1)"]
+ssm = ["PyYAML (>=5.1)", "dataclasses"]
 xray = ["aws-xray-sdk (>=0.93,!=0.96)", "setuptools"]
 
 [[package]]
@@ -1214,6 +1172,20 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "pproxy"
+version = "2.7.8"
+description = "Proxy server that can tunnel among remote servers by regex rules."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+accelerated = ["pycryptodome (>=3.7.2)", "uvloop (>=0.13.0)"]
+daemon = ["python-daemon (>=2.2.3)"]
+quic = ["aioquic (>=0.9.7)"]
+sshtunnel = ["asyncssh (>=2.5.0)"]
+
+[[package]]
 name = "priority"
 version = "2.0.0"
 description = "A pure-Python implementation of the HTTP/2 priority tree"
@@ -1289,14 +1261,6 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
-name = "pympler"
-version = "0.9"
-description = "A development tool to measure, monitor and analyze the memory behavior of Python objects."
-category = "dev"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "pyopenssl"
 version = "17.5.0"
 description = "Python wrapper module around the OpenSSL library"
@@ -1319,17 +1283,6 @@ description = "Python parsing module"
 category = "dev"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-
-[[package]]
-name = "pypiwin32"
-version = "223"
-description = ""
-category = "dev"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-pywin32 = ">=223"
 
 [[package]]
 name = "pyrsistent"
@@ -1391,21 +1344,6 @@ toml = "*"
 testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
-name = "pytest-httpserver"
-version = "1.0.1"
-description = "pytest-httpserver is a httpserver for pytest"
-category = "dev"
-optional = false
-python-versions = ">=3.4"
-
-[package.dependencies]
-werkzeug = "*"
-
-[package.extras]
-dev = ["flake8", "wheel", "pytest", "pytest-cov", "coverage", "ipdb", "requests", "sphinx", "sphinx-rtd-theme", "reno", "autopep8"]
-test = ["pytest", "pytest-cov", "coverage", "requests"]
-
-[[package]]
 name = "pytest-lazy-fixture"
 version = "0.6.3"
 description = "It helps to use fixtures in pytest.mark.parametrize"
@@ -1429,17 +1367,6 @@ pytest = ">=5.0"
 
 [package.extras]
 dev = ["pre-commit", "tox", "pytest-asyncio"]
-
-[[package]]
-name = "pytest-rerunfailures"
-version = "10.0"
-description = "pytest plugin to re-run tests to eliminate flaky failures"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-pytest = ">=5.3"
 
 [[package]]
 name = "python-dateutil"
@@ -1482,7 +1409,7 @@ python-versions = "*"
 
 [[package]]
 name = "pywin32"
-version = "300"
+version = "227"
 description = "Python for Window Extensions"
 category = "dev"
 optional = false
@@ -1639,17 +1566,6 @@ botocore = ">=1.12.36,<2.0a.0"
 
 [package.extras]
 crt = ["botocore[crt] (>=1.20.29,<2.0a.0)"]
-
-[[package]]
-name = "sasl"
-version = "0.3.1"
-description = "Cyrus-SASL bindings for Python"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-six = "*"
 
 [[package]]
 name = "scout-apm"
@@ -1930,7 +1846,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "852657b98bc7da7aad387cc326b29c8172cfe2bf9555215bd4d9b5a32fe3b881"
+content-hash = "5dbd8b5e9dba205b52ed1ff4ce029e48e786e96b944e87e83e72dec51ca4c266"
 
 [metadata.files]
 aiobotocore = [
@@ -2183,10 +2099,6 @@ coverage = [
     {file = "coverage-5.5-pp37-none-any.whl", hash = "sha256:2a3859cb82dcbda1cfd3e6f71c27081d18aa251d20a17d87d26d4cd216fb0af4"},
     {file = "coverage-5.5.tar.gz", hash = "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c"},
 ]
-coveralls = [
-    {file = "coveralls-3.1.0-py2.py3-none-any.whl", hash = "sha256:172fb79c5f61c6ede60554f2cac46deff6d64ee735991fb2124fb414e188bdb4"},
-    {file = "coveralls-3.1.0.tar.gz", hash = "sha256:9b3236e086627340bf2c95f89f757d093cbed43d17179d3f4fb568c347e7d29a"},
-]
 crontab = [
     {file = "crontab-0.23.0.tar.gz", hash = "sha256:ca79dede9c2f572bb32f38703e8fddcf3427e86edc838f2ffe7ae4b9ee2b0733"},
 ]
@@ -2223,11 +2135,8 @@ dnspython = [
     {file = "dnspython-1.16.0.zip", hash = "sha256:36c5e8e38d4369a08b6780b7f27d790a292b2b08eea01607865bf0936c558e01"},
 ]
 docker = [
-    {file = "docker-4.2.2-py2.py3-none-any.whl", hash = "sha256:03a46400c4080cb6f7aa997f881ddd84fef855499ece219d75fbdb53289c17ab"},
-    {file = "docker-4.2.2.tar.gz", hash = "sha256:26eebadce7e298f55b76a88c4f8802476c5eaddbdbe38dbc6cce8781c47c9b54"},
-]
-docopt = [
-    {file = "docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"},
+    {file = "docker-5.0.0-py2.py3-none-any.whl", hash = "sha256:fc961d622160e8021c10d1bcabc388c57d55fb1f917175afbe24af442e6879bd"},
+    {file = "docker-5.0.0.tar.gz", hash = "sha256:3e8bc47534e0ca9331d72c32f2881bb13b93ded0bcdeab3c833fb7cf61c0a9a5"},
 ]
 docutils = [
     {file = "docutils-0.15.2-py2-none-any.whl", hash = "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827"},
@@ -2282,9 +2191,6 @@ flask-cors = [
 ]
 flask-swagger = [
     {file = "flask-swagger-0.2.12.tar.gz", hash = "sha256:c0e55fff208193174746e49177604423e339fc8a8c945821272c0cf5db46f326"},
-]
-forbiddenfruit = [
-    {file = "forbiddenfruit-0.1.3.tar.gz", hash = "sha256:1188a07cc24a9bd2c529dad06490b80a6fc88cde968af4d7861da81686b2cc8c"},
 ]
 future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
@@ -2523,7 +2429,7 @@ junit-xml = [
     {file = "junit_xml-1.9-py2.py3-none-any.whl", hash = "sha256:ec5ca1a55aefdd76d28fcc0b135251d156c7106fa979686a4b48d62b761b4732"},
 ]
 localstack = [
-    {file = "localstack-0.12.17.3.tar.gz", hash = "sha256:296b16612fc1c96426b064e5f294ca33ed3dc638673061e22f68388a0206e389"},
+    {file = "localstack-0.12.18.1.tar.gz", hash = "sha256:ee74e7a76db6d2697713f0434e9190b5f1ea8c431b93a3ed6b3c976ebbb4ff0d"},
 ]
 localstack-client = [
     {file = "localstack-client-1.25.tar.gz", hash = "sha256:8a0c6da8a07d3324fc6948071281d59d6a71e31386cf959a9fcde77d57c1da7b"},
@@ -2612,8 +2518,8 @@ more-itertools = [
     {file = "more_itertools-8.10.0-py3-none-any.whl", hash = "sha256:56ddac45541718ba332db05f464bebfb0768110111affd27f66e0051f276fa43"},
 ]
 moto-ext = [
-    {file = "moto-ext-2.2.3.2.tar.gz", hash = "sha256:6f852edad28b57c30c8f8889b45631750fab3c7ffb88ed1ba9c9e2ce0484556a"},
-    {file = "moto_ext-2.2.3.2-py2.py3-none-any.whl", hash = "sha256:f9221e86998a3e50fe8824fd9b5b126ea1aa8a5405a26c386555edc302892c76"},
+    {file = "moto-ext-2.2.3.4.tar.gz", hash = "sha256:a6a6f778eb771990ff7707c50a3c0a5cccbef7d32e8383743a62fe7b0ece14ce"},
+    {file = "moto_ext-2.2.3.4-py2.py3-none-any.whl", hash = "sha256:f5c12bcfb36eebc57f5c09e1aabb8a9e565e95cacfd0358e6eeb245df1348230"},
 ]
 msgpack = [
     {file = "msgpack-1.0.0-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:cec8bf10981ed70998d98431cd814db0ecf3384e6b113366e7f36af71a0fca08"},
@@ -2727,6 +2633,10 @@ ply = [
     {file = "ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"},
     {file = "ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},
 ]
+pproxy = [
+    {file = "pproxy-2.7.8-py3-none-any.whl", hash = "sha256:9f300bae5288c7c7f56be70d6275571efd2b4862f306d25bdace3c3537fb53a7"},
+    {file = "pproxy-2.7.8.tar.gz", hash = "sha256:fab73cc13b2bb10c9fc4d9c1a8ec8011a354c9bcbffa446d91229e13c5d996c8"},
+]
 priority = [
     {file = "priority-2.0.0-py3-none-any.whl", hash = "sha256:6f8eefce5f3ad59baf2c080a664037bb4725cd0a790d53d59ab4059288faf6aa"},
     {file = "priority-2.0.0.tar.gz", hash = "sha256:c965d54f1b8d0d0b19479db3924c7c36cf672dbf2aec92d43fbdaf4492ba18c0"},
@@ -2782,9 +2692,6 @@ pygments = [
     {file = "Pygments-2.10.0-py3-none-any.whl", hash = "sha256:b8e67fe6af78f492b3c4b3e2970c0624cbf08beb1e493b2c99b9fa1b67a20380"},
     {file = "Pygments-2.10.0.tar.gz", hash = "sha256:f398865f7eb6874156579fdf36bc840a03cab64d1cde9e93d68f46a425ec52c6"},
 ]
-pympler = [
-    {file = "Pympler-0.9.tar.gz", hash = "sha256:f2cbe7df622117af890249f2dea884eb702108a12d729d264b7c5983a6e06e47"},
-]
 pyopenssl = [
     {file = "pyOpenSSL-17.5.0-py2.py3-none-any.whl", hash = "sha256:07a2de1a54de07448732a81e38a55df7da109b2f47f599f8bb35b0cbec69d4bd"},
     {file = "pyOpenSSL-17.5.0.tar.gz", hash = "sha256:2c10cfba46a52c0b0950118981d61e72c1e5b1aac451ca1bc77de1a679456773"},
@@ -2792,10 +2699,6 @@ pyopenssl = [
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
-]
-pypiwin32 = [
-    {file = "pypiwin32-223-py3-none-any.whl", hash = "sha256:67adf399debc1d5d14dffc1ab5acacb800da569754fafdc576b2a039485aa775"},
-    {file = "pypiwin32-223.tar.gz", hash = "sha256:71be40c1fbd28594214ecaecb58e7aa8b708eabfa0125c8a109ebd51edbd776a"},
 ]
 pyrsistent = [
     {file = "pyrsistent-0.18.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f4c8cabb46ff8e5d61f56a037974228e978f26bfefce4f61a4b1ac0ba7a2ab72"},
@@ -2832,10 +2735,6 @@ pytest-cov = [
     {file = "pytest-cov-2.12.1.tar.gz", hash = "sha256:261ceeb8c227b726249b376b8526b600f38667ee314f910353fa318caa01f4d7"},
     {file = "pytest_cov-2.12.1-py2.py3-none-any.whl", hash = "sha256:261bb9e47e65bd099c89c3edf92972865210c36813f80ede5277dceb77a4a62a"},
 ]
-pytest-httpserver = [
-    {file = "pytest_httpserver-1.0.1-py3-none-any.whl", hash = "sha256:3b2663b539849a2e5bd7d7f380a99b19c4650e154581af699ad6431b5424cacc"},
-    {file = "pytest_httpserver-1.0.1.tar.gz", hash = "sha256:e359c5722ce2bd3bb68f4606f57d5c846e52bf7c748a70de4a3097bb91006089"},
-]
 pytest-lazy-fixture = [
     {file = "pytest-lazy-fixture-0.6.3.tar.gz", hash = "sha256:0e7d0c7f74ba33e6e80905e9bfd81f9d15ef9a790de97993e34213deb5ad10ac"},
     {file = "pytest_lazy_fixture-0.6.3-py3-none-any.whl", hash = "sha256:e0b379f38299ff27a653f03eaa69b08a6fd4484e46fd1c9907d984b9f9daeda6"},
@@ -2843,10 +2742,6 @@ pytest-lazy-fixture = [
 pytest-mock = [
     {file = "pytest-mock-3.6.1.tar.gz", hash = "sha256:40217a058c52a63f1042f0784f62009e976ba824c418cced42e88d5f40ab0e62"},
     {file = "pytest_mock-3.6.1-py3-none-any.whl", hash = "sha256:30c2f2cc9759e76eee674b81ea28c9f0b94f8f0445a1b87762cadf774f0df7e3"},
-]
-pytest-rerunfailures = [
-    {file = "pytest-rerunfailures-10.0.tar.gz", hash = "sha256:3906e611f962e3bdf15501e8a24ad2d12a703eff7d2030ea88acf68ad8d6b391"},
-    {file = "pytest_rerunfailures-10.0-py3-none-any.whl", hash = "sha256:fb5f276df942944da80f3c7a84507ac4f92cc3f462fe6bd4bbcbef94de22db8b"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},
@@ -2861,16 +2756,18 @@ pytz = [
     {file = "pytz-2021.1.tar.gz", hash = "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da"},
 ]
 pywin32 = [
-    {file = "pywin32-300-cp35-cp35m-win32.whl", hash = "sha256:1c204a81daed2089e55d11eefa4826c05e604d27fe2be40b6bf8db7b6a39da63"},
-    {file = "pywin32-300-cp35-cp35m-win_amd64.whl", hash = "sha256:350c5644775736351b77ba68da09a39c760d75d2467ecec37bd3c36a94fbed64"},
-    {file = "pywin32-300-cp36-cp36m-win32.whl", hash = "sha256:a3b4c48c852d4107e8a8ec980b76c94ce596ea66d60f7a697582ea9dce7e0db7"},
-    {file = "pywin32-300-cp36-cp36m-win_amd64.whl", hash = "sha256:27a30b887afbf05a9cbb05e3ffd43104a9b71ce292f64a635389dbad0ed1cd85"},
-    {file = "pywin32-300-cp37-cp37m-win32.whl", hash = "sha256:d7e8c7efc221f10d6400c19c32a031add1c4a58733298c09216f57b4fde110dc"},
-    {file = "pywin32-300-cp37-cp37m-win_amd64.whl", hash = "sha256:8151e4d7a19262d6694162d6da85d99a16f8b908949797fd99c83a0bfaf5807d"},
-    {file = "pywin32-300-cp38-cp38-win32.whl", hash = "sha256:fbb3b1b0fbd0b4fc2a3d1d81fe0783e30062c1abed1d17c32b7879d55858cfae"},
-    {file = "pywin32-300-cp38-cp38-win_amd64.whl", hash = "sha256:60a8fa361091b2eea27f15718f8eb7f9297e8d51b54dbc4f55f3d238093d5190"},
-    {file = "pywin32-300-cp39-cp39-win32.whl", hash = "sha256:638b68eea5cfc8def537e43e9554747f8dee786b090e47ead94bfdafdb0f2f50"},
-    {file = "pywin32-300-cp39-cp39-win_amd64.whl", hash = "sha256:b1609ce9bd5c411b81f941b246d683d6508992093203d4eb7f278f4ed1085c3f"},
+    {file = "pywin32-227-cp27-cp27m-win32.whl", hash = "sha256:371fcc39416d736401f0274dd64c2302728c9e034808e37381b5e1b22be4a6b0"},
+    {file = "pywin32-227-cp27-cp27m-win_amd64.whl", hash = "sha256:4cdad3e84191194ea6d0dd1b1b9bdda574ff563177d2adf2b4efec2a244fa116"},
+    {file = "pywin32-227-cp35-cp35m-win32.whl", hash = "sha256:f4c5be1a293bae0076d93c88f37ee8da68136744588bc5e2be2f299a34ceb7aa"},
+    {file = "pywin32-227-cp35-cp35m-win_amd64.whl", hash = "sha256:a929a4af626e530383a579431b70e512e736e9588106715215bf685a3ea508d4"},
+    {file = "pywin32-227-cp36-cp36m-win32.whl", hash = "sha256:300a2db938e98c3e7e2093e4491439e62287d0d493fe07cce110db070b54c0be"},
+    {file = "pywin32-227-cp36-cp36m-win_amd64.whl", hash = "sha256:9b31e009564fb95db160f154e2aa195ed66bcc4c058ed72850d047141b36f3a2"},
+    {file = "pywin32-227-cp37-cp37m-win32.whl", hash = "sha256:47a3c7551376a865dd8d095a98deba954a98f326c6fe3c72d8726ca6e6b15507"},
+    {file = "pywin32-227-cp37-cp37m-win_amd64.whl", hash = "sha256:31f88a89139cb2adc40f8f0e65ee56a8c585f629974f9e07622ba80199057511"},
+    {file = "pywin32-227-cp38-cp38-win32.whl", hash = "sha256:7f18199fbf29ca99dff10e1f09451582ae9e372a892ff03a28528a24d55875bc"},
+    {file = "pywin32-227-cp38-cp38-win_amd64.whl", hash = "sha256:7c1ae32c489dc012930787f06244426f8356e129184a02c25aef163917ce158e"},
+    {file = "pywin32-227-cp39-cp39-win32.whl", hash = "sha256:c054c52ba46e7eb6b7d7dfae4dbd987a1bb48ee86debe3f245a2884ece46e295"},
+    {file = "pywin32-227-cp39-cp39-win_amd64.whl", hash = "sha256:f27cec5e7f588c3d1051651830ecc00294f90728d19c3bf6916e6dba93ea357c"},
 ]
 pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922"},
@@ -2992,9 +2889,6 @@ rsa = [
 s3transfer = [
     {file = "s3transfer-0.4.2-py2.py3-none-any.whl", hash = "sha256:9b3752887a2880690ce628bc263d6d13a3864083aeacff4890c1c9839a5eb0bc"},
     {file = "s3transfer-0.4.2.tar.gz", hash = "sha256:cb022f4b16551edebbb31a377d3f09600dbada7363d8c5db7976e7f47732e1b2"},
-]
-sasl = [
-    {file = "sasl-0.3.1.tar.gz", hash = "sha256:0695030b23faa65aab2b462ce6f067d61caeb406de22d1ca7f9253fd9ebe127e"},
 ]
 scout-apm = [
     {file = "scout_apm-2.19.0-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:6f4f79932b1ce33c0f0d51a1d7475e45d466f19d1e5305b28f554c77ebeb59a9"},

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -35,7 +35,7 @@ locust = "^1.5.3"
 websocket_client = "^1.1.0"
 pytest-cov = "^2.12.1"
 time-machine = "^2.1.0"
-localstack = {extras = ["full"], version = "^0.12.16"}
+localstack = {extras = ["full"], version = "^0.12.18"}
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,11 +15,6 @@ services:
       SCOUT_MONITOR:
       USE_SSL: "true"
       LOG_LEVEL:
-      # Enable the legacy docker client for localstack
-      # The Sdk docker client crashes if docker isn't available, even though it's just checking for a container name,
-      # which is not necessary to run the tests
-      # https://github.com/localstack/localstack/issues/4692
-      LEGACY_DOCKER_CLIENT: "true"
       SSL_CRT_FILE: /certs/ttbud.local.pem
       SSL_KEY_FILE: /certs/ttbud.local-key.pem
       PORT: ${API_WEBSOCKET_PORT}


### PR DESCRIPTION
Version 0.12.18 fixes
https://github.com/localstack/localstack/issues/4692 and no longer
requires the docker cli to be installed on the host
